### PR TITLE
Ubuntu Snap Browser Warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ For macOS developers, see [this](#development-on-macos)
 ### Linux
 Follow the instructions here [https://github.com/glaubitz/linux-minidisc/tree/master/netmd/etc](https://github.com/glaubitz/linux-minidisc/tree/master/netmd/etc) to grant your user access to the device. If you skip this step you'll likely get an *Access denied* message when trying to connect.
 
+*Ubuntu users* - Avoid using browsers installed via Snap as Snap's permission structure is different from traditionally installed applications and will lead to access denied errors. 
+
 ### Windows
 The Windows USB stack requires a driver to be installed to communicate with any USB device. The bad news is that there are no official Windows 10 drivers for NetMD devices. The good news is that we don't need it!
 We can just use a generic driver like *WinUSB* to access the device.


### PR DESCRIPTION
I found that regardless of udev rules I would get **Access Denied** errors on Ubuntu using Chromium installed via Snap. Switching to a non-Snap installed browser resolved the issue. It may be possible to change permissions for the app as a workaround but the path of least resistance is just using a different browser.

Further info: [https://ubuntu.com/blog/a-guide-to-snap-permissions-and-interfaces](https://ubuntu.com/blog/a-guide-to-snap-permissions-and-interfaces)