### PR TITLE
Fix build directory in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3
 
 RUN apk add busybox-extras tini
 
-COPY build/ webminidisc/
+COPY dist/ webminidisc/
 
 ENTRYPOINT [ "/sbin/tini", "-g", "--" ]
 CMD [ "httpd", "-f", "-h", "/webminidisc", "-p", "8080" ]


### PR DESCRIPTION
Vite writes build artifacts to dist/ instead of build/.