### PR TITLE
Replace all disallowed characters in ZIP file names

### DIFF
--- a/src/redux/factory/factory-actions.ts
+++ b/src/redux/factory/factory-actions.ts
@@ -397,7 +397,8 @@ export function archiveDisc() {
         let zip: JSZip | null = null;
         if (archiveDiscCreateZip) {
             zip = new JSZip();
-            callback = (blob: Blob, fileName: string) => zip!.file(fileName.replace(/\//g, '-').replace('\\', '-'), blob);
+            const disallowedCharacters = /[<>:"/\\|?*]/g;
+            callback = (blob: Blob, fileName: string) => zip!.file(fileName.replace(disallowedCharacters, '_'), blob);
         }
         let toc = getState().factory.toc;
         if (!toc) {


### PR DESCRIPTION
Replace all characters that aren't allowed in Windows filenames with an underscore when creating a ZIP archive. This prevents errors when extracting the archive onto a Windows filesystem.