### PR TITLE
Correctly handle bulk track deletion

### DIFF
--- a/src/services/interfaces/netmd-mock.ts
+++ b/src/services/interfaces/netmd-mock.ts
@@ -283,7 +283,7 @@ class NetMDMockService extends NetMDService {
     }
 
     async deleteTracks(indexes: number[]) {
-        indexes = indexes.sort();
+        indexes = indexes.sort((a, b) => a - b);
         indexes.reverse();
         for (const index of indexes) {
             this._groupsDef = recomputeGroupsAfterTrackMove(this._getDisc(), index, -1).groups.map(g => ({

--- a/src/services/interfaces/netmd.ts
+++ b/src/services/interfaces/netmd.ts
@@ -610,7 +610,7 @@ export class NetMDUSBService extends NetMDService {
         try {
             // await this.netmdInterface!.stop();
         } catch (ex) {}
-        indexes = indexes.sort();
+        indexes = indexes.sort((a, b) => a - b);
         indexes.reverse();
         let content = await this.listContentUsingCache();
         for (const index of indexes) {


### PR DESCRIPTION
Bulk track deletion implementation relies on track numbers being deleted to be sorted numerically. However, the sorting was done by ASCII character order leanding to deletion of unexpected tracks in some cases.

[2,3,11].sort() //  [11, 2, 3]