### PR TITLE
Include setDiscSwapDetection to implement basclasss

### DIFF
--- a/src/services/interfaces/netmd-mock.ts
+++ b/src/services/interfaces/netmd-mock.ts
@@ -461,6 +461,7 @@ class NetMDMockService extends NetMDService {
 class NetMDFactoryMockService implements NetMDFactoryService {
     async prepareDownload(): Promise<void> {}
     async finalizeDownload(): Promise<void> {}
+    async setDiscSwapDetection(enable: boolean): Promise<void> {}
     async uploadSP(
         title: string,
         fullWidthTitle: string,


### PR DESCRIPTION
In NetMDFactoryMockService currently is missing one base class method, without it building will create type errors as described in issue #60 