### PR TITLE
Add option to strip leading track numbers in upload titles

### DIFF
--- a/src/components/convert-dialog.tsx
+++ b/src/components/convert-dialog.tsx
@@ -3,6 +3,7 @@ import { useDispatch } from '../frontend-utils';
 import {
     getMetadataFromFile,
     removeExtension,
+    stripTrackNumbers,
     secondsToHumanReadable,
     getATRACWAVEncoding,
     getATRACOMAEncoding,
@@ -243,7 +244,7 @@ export const ConvertDialog = (props: { files: (File | AdaptiveFile)[] }) => {
     const dispatch = useDispatch();
     const { classes, cx } = useStyles();
 
-    const { visible, format, titleFormat, titles } = useShallowEqualSelector((state) => state.convertDialog);
+    const { visible, format, titleFormat, titles, stripTrackNumbers: stripTrackNumbersEnabled } = useShallowEqualSelector((state) => state.convertDialog);
     const { fullWidthSupport } = useShallowEqualSelector((state) => state.appState);
     const { disc, deviceCapabilities } = useShallowEqualSelector((state) => state.main);
     const minidiscSpec = serviceRegistry.netmdSpec!;
@@ -397,30 +398,34 @@ export const ConvertDialog = (props: { files: (File | AdaptiveFile)[] }) => {
             dispatch(
                 convertDialogActions.setTitles(
                     files.map((file) => {
+                        const trackTitle = stripTrackNumbersEnabled ? stripTrackNumbers(file.title) : file.title;
                         let rawTitle = '';
                         switch (format) {
                             case 'title': {
-                                rawTitle = file.title;
+                                rawTitle = trackTitle;
                                 break;
                             }
                             case 'artist-title': {
-                                rawTitle = `${file.artist} - ${file.title}`;
+                                rawTitle = `${file.artist} - ${trackTitle}`;
                                 break;
                             }
                             case 'title-artist': {
-                                rawTitle = `${file.title} - ${file.artist}`;
+                                rawTitle = `${trackTitle} - ${file.artist}`;
                                 break;
                             }
                             case 'album-title': {
-                                rawTitle = `${file.album} - ${file.title}`;
+                                rawTitle = `${file.album} - ${trackTitle}`;
                                 break;
                             }
                             case 'artist-album-title': {
-                                rawTitle = `${file.artist} - ${file.album} - ${file.title}`;
+                                rawTitle = `${file.artist} - ${file.album} - ${trackTitle}`;
                                 break;
                             }
                             case 'filename': {
                                 rawTitle = removeExtension(file.file.name);
+                                if (stripTrackNumbersEnabled) {
+                                    rawTitle = stripTrackNumbers(rawTitle);
+                                }
                                 break;
                             }
                         }
@@ -440,7 +445,7 @@ export const ConvertDialog = (props: { files: (File | AdaptiveFile)[] }) => {
                 )
             );
         },
-        [fullWidthSupport, dispatch, minidiscSpec, deviceSupportsFullWidth]
+        [fullWidthSupport, dispatch, minidiscSpec, deviceSupportsFullWidth, stripTrackNumbersEnabled]
     );
 
     const renameTrackManually = useCallback(
@@ -543,6 +548,10 @@ export const ConvertDialog = (props: { files: (File | AdaptiveFile)[] }) => {
     const handleToggleReplayGain = useCallback(() => {
         setEnableReplayGain((enableReplayGain) => !enableReplayGain);
     }, [setEnableReplayGain]);
+
+    const handleToggleStripTrackNumbers = useCallback(() => {
+        dispatch(convertDialogActions.setStripTrackNumbers(!stripTrackNumbersEnabled));
+    }, [dispatch, stripTrackNumbersEnabled]);
 
     const handleToggleFullWidthSupport = useCallback(() => {
         dispatch(appActions.setFullWidthSupport(!fullWidthSupport));
@@ -1148,6 +1157,12 @@ export const ConvertDialog = (props: { files: (File | AdaptiveFile)[] }) => {
                             label={`Use ReplayGain`}
                             className={classes.advancedOption}
                             control={<Checkbox checked={enableReplayGain} onChange={handleToggleReplayGain} />}
+                        />
+
+                        <FormControlLabel
+                            label={`Strip leading track numbers`}
+                            className={classes.advancedOption}
+                            control={<Checkbox checked={stripTrackNumbersEnabled} onChange={handleToggleStripTrackNumbers} />}
                         />
                     </AccordionDetails>
                 </Accordion>

--- a/src/redux/convert-dialog-feature.ts
+++ b/src/redux/convert-dialog-feature.ts
@@ -11,6 +11,7 @@ export interface ConvertDialogFeature {
     visible: boolean;
     format: { [mdSpecName: string]: [number, number] };
     titleFormat: TitleFormatType;
+    stripTrackNumbers: boolean;
     titles: {
         title: string;
         fullWidthTitle: string;
@@ -26,6 +27,7 @@ const initialState: ConvertDialogFeature = {
     visible: false,
     format: loadPreference('uploadFormat', {}),
     titleFormat: loadPreference('trackTitleFormat', 'filename') as TitleFormatType,
+    stripTrackNumbers: loadPreference('stripTrackNumbers', false),
     titles: [],
 };
 
@@ -43,6 +45,10 @@ const slice = createSlice({
         setTitleFormat: (state, action: PayloadAction<TitleFormatType>) => {
             state.titleFormat = action.payload;
             savePreference('trackTitleFormat', state.titleFormat);
+        },
+        setStripTrackNumbers: (state, action: PayloadAction<boolean>) => {
+            state.stripTrackNumbers = action.payload;
+            savePreference('stripTrackNumbers', state.stripTrackNumbers);
         },
         setTitles: (
             state,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -35,6 +35,10 @@ export function debounce<T extends Function>(func: T, timeout = 300): T {
     return (debouncedFn as any) as T;
 }
 
+export function stripTrackNumbers(title: string) {
+    return title.replace(/^\s*(?:(?:\(\d{1,3}\)|\d{1,3})(?:[.\-_:\s]+|$)){1,5}/, '').trimStart();
+}
+
 export function removeExtension(filename: string) {
     const extStartIndex = filename.lastIndexOf('.');
     if (extStartIndex > 0) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -36,7 +36,10 @@ export function debounce<T extends Function>(func: T, timeout = 300): T {
 }
 
 export function stripTrackNumbers(title: string) {
-    return title.replace(/^\s*(?:(?:\(\d{1,3}\)|\d{1,3})(?:[.\-_:\s]+|$)){1,5}/, '').trimStart();
+    const cleaned = title
+        .replace(/^\s*(?:(?:\(\d{1,3}\)|\d{1,3})(?:[.\-_\s]+|$)){1,5}/, '')
+        .trimStart();
+    return cleaned.length ? cleaned : title;
 }
 
 export function removeExtension(filename: string) {


### PR DESCRIPTION
## Summary
Adds an optional bulk rename toggle in **Upload Settings**:

- **Advanced Options → Strip leading track numbers**
- When enabled, leading numeric prefixes are removed from generated titles
  - Examples: `01 Title`, `01-01-01 Title`, `(01) 02 Title` -> `Title`
- Default is **off** (no behavior change unless enabled)

## Why
In real uploads (especially with weak/missing metadata), titles often include unwanted index prefixes.
Editing each track manually is tedious, so this adds a one-click cleanup step.

## Behavior Change
- Before: `Unknown Artist - 01 Supernova`
- After (toggle ON): `Unknown Artist - Supernova`

Works for both filename-derived and metadata-derived title flows used in this dialog.

## Tradeoff (Code Aesthetics)
A few implementation shapes were considered:

- A more “clean architecture” refactor (extract title builder + tests)
- Very minimal local patching inside existing switch logic

This PR intentionally chooses the smaller patch:
- keeps changes localized
- avoids large structural edits in non-owned code
- ships useful behavior quickly

Cost:
- code is not as “perfectly factored” as a dedicated refactor would be

Given scope, this is a pragmatic balance between readability and minimal churn.


<img width="458" height="929" alt="image" src="https://github.com/user-attachments/assets/881fb87f-feeb-404e-94dc-b988991bf626" />
<img width="463" height="933" alt="image" src="https://github.com/user-attachments/assets/c6f01b8a-ec57-4ec0-b090-3515d7827404" />
